### PR TITLE
Fix #276 Icons size in legend are too big 

### DIFF
--- a/src/main/resources/META-INF/resources/webjars/service/prov/prov.css
+++ b/src/main/resources/META-INF/resources/webjars/service/prov/prov.css
@@ -524,7 +524,7 @@ img.flag-icon.prov-location-flag {
 #instance-gpu{
   width: 6em;
 }
-#subscribe-configuration-prov foreignObject i {
+#subscribe-configuration-prov .prov-barchart-svg g.legend  i {
   font-size: 13px;
   margin-left: 1px;
   opacity: 0.5;


### PR DESCRIPTION
<img width="110" alt="Capture d’écran 2023-04-24 à 09 10 01" src="https://user-images.githubusercontent.com/72598333/233924035-9329625e-e967-4d2d-ae9d-924f43e3fa5a.png">
