### PR TITLE
#278 Prevent multiline in table column names Fix 

### DIFF
--- a/src/main/resources/META-INF/resources/webjars/service/prov/prov.js
+++ b/src/main/resources/META-INF/resources/webjars/service/prov/prov.js
@@ -4726,7 +4726,7 @@ define(['sparkline', 'd3'], function () {
 				},
 				{
 					data: 'price.term',
-					className: 'hidden-xs hidden-sm price-term',
+					className: 'truncate hidden-xs hidden-sm price-term',
 					type: 'string',
 					render: formatInstanceTerm
 				}, {
@@ -4736,25 +4736,25 @@ define(['sparkline', 'd3'], function () {
 					render: formatInstanceType
 				}, {
 					data: 'usage',
-					className: 'hidden-xs hidden-sm usage',
+					className: 'truncate hidden-xs hidden-sm usage',
 					type: 'string',
 					render: formatUsage,
 					filter: filterMultiScoped('usage')
 				}, {
 					data: 'budget',
-					className: 'hidden-xs hidden-sm budget',
+					className: 'truncate hidden-xs hidden-sm budget',
 					type: 'string',
 					render: formatBudget,
 					filter: filterMultiScoped('budget')
 				}, {
 					data: 'optimizer',
-					className: 'hidden-xs hidden-sm optimizer',
+					className: 'truncate hidden-xs hidden-sm optimizer',
 					type: 'string',
 					render: formatOptimizer,
 					filter: filterMultiScoped('optimizer')
 				}, {
 					data: 'location',
-					className: 'hidden-xs hidden-sm location',
+					className: 'truncate hidden-xs hidden-sm location',
 					width: '24px',
 					type: 'string',
 					render: formatLocation


### PR DESCRIPTION
Before : 
<img width="223" alt="Capture d’écran 2023-04-24 à 09 15 04" src="https://user-images.githubusercontent.com/72598333/233925034-859cb4f6-0bdf-495a-92fa-b386bea026f8.png">

After :
<img width="234" alt="Capture d’écran 2023-04-24 à 09 15 33" src="https://user-images.githubusercontent.com/72598333/233925139-58722e01-4d93-4582-87ef-d11d377bc4e6.png">
