### PR TITLE
Fix #299 After resource filter selection, computed cost corresponds to the unfiltered sum

### DIFF
--- a/src/main/resources/META-INF/resources/webjars/service/prov/lib/stacked.js
+++ b/src/main/resources/META-INF/resources/webjars/service/prov/lib/stacked.js
@@ -281,9 +281,9 @@ define(['d3', 'jquery'], function (d3) {
                             bars.each(o => o.clicked = d)
                                 .attr('class', 'clicked')
                                 .attr('fill', o => d3.rgb(params.color(o.cluster)).darker());
-                            params.hover(d,params.chosen.cluster);
+                            params.hover(null);
                         }
-                        params.click(d, blockData.filter(f => f.x === d.x), params.clicked && true || false);
+                        params.click(d, blockData.filter(f => f.x === d.x), params.clicked && true || false, params.chosen.cluster|| null);
                     }
                 })
                 .on('mouseleave', function (e, previousData) {


### PR DESCRIPTION
<img width="1154" alt="Capture d’écran 2023-05-23 à 09 46 43" src="https://github.com/ligoj/plugin-prov/assets/72598333/b9ef8d44-f3ed-44a3-9e54-4fdb3dcd4f03">
